### PR TITLE
Option to create new certs directly to output

### DIFF
--- a/scripts/genclient.sh
+++ b/scripts/genclient.sh
@@ -38,7 +38,10 @@ then
                 FILE_PATH="$CLIENT_PATH/$FILE_NAME"
             fi
             ;;
-
+        o)
+                cat "$FILE_PATH"
+                exit 0
+            ;;
         *) echo "$(datef) Unknown parameters $FLAGS"
             ;;
 


### PR DESCRIPTION
I was trying to use your project for personal purposes, and I've found that it is hard to use that in case if there is already a busy 80th port.
And it doesn't seem to me that it is fine to create a period of time, when everyone in the Internet can get access to the certificate.

In my case I've changed the line, replacing `-p 80:8080` with `-p 127.0.0.1:81:8080`, and after that I did a curl request to localhost:81.

If you like the idea, I would also add description into the README.md as well.

The change allows you to pick the third option like `docker exec dockovpn ./genclient.sh o > my_cert.ovpn`. 

Looking forward to hearing your opinion about that. 
