### PR TITLE
Added 4th and 5th options to send zip with or without a password

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -44,20 +44,28 @@ function createConfig() {
 
 function zipFiles() {
     CLIENT_PATH="$1"
+    IS_QUITE="$2"
+
     # -q to silence zip output
     # -j junk directories
     zip -q -j "$CLIENT_PATH/client.zip" "$CLIENT_PATH/client.ovpn"
-
-    echo "$(datef) $CLIENT_PATH/client.zip file has been generated"
+    if [[ "$IS_QUITE" -ne "-q" ]]
+    then
+       echo "$(datef) $CLIENT_PATH/client.zip file has been generated"
+    fi
 }
 
 function zipFilesWithPassword() {
     CLIENT_PATH="$1"
     ZIP_PASSWORD="$2"
+    IS_QUITE="$3"
     # -q to silence zip output
     # -j junk directories
     # -P pswd use standard encryption, password is pswd
     zip -q -j -P "$ZIP_PASSWORD" "$CLIENT_PATH/client.zip" "$CLIENT_PATH/client.ovpn"
 
-    echo "$(datef) $CLIENT_PATH/client.zip with password protection has been generated"
+    if [[ "$IS_QUITE" -ne "-q" ]]
+    then
+       echo "$(datef) $CLIENT_PATH/client.zip with password protection has been generated"
+    fi
 }

--- a/scripts/genclient.sh
+++ b/scripts/genclient.sh
@@ -6,7 +6,6 @@ CLIENT_PATH="$(createConfig)"
 CONTENT_TYPE=application/text
 FILE_NAME=client.ovpn
 FILE_PATH="$CLIENT_PATH/$FILE_NAME"
-echo "$(datef) $FILE_PATH file has been generated"
 
 if (($#))
 then
@@ -19,6 +18,7 @@ then
     # Switch statement
     case $FLAGS in
         z)
+	    echo "$(datef) $FILE_PATH file has been generated"
             zipFiles "$CLIENT_PATH"
 
             CONTENT_TYPE=application/zip
@@ -26,10 +26,11 @@ then
             FILE_PATH="$CLIENT_PATH/$FILE_NAME"
             ;;
         zp)
+	    echo "$(datef) $FILE_PATH file has been generated"
             # (()) engaes arthimetic context
             if (($# < 2))
             then
-                echo "$(datef) Not enogh arguments" && exit 0
+                echo "$(datef) Not enough arguments" && exit 1
             else
                 zipFilesWithPassword "$CLIENT_PATH" "$2"
 
@@ -42,6 +43,27 @@ then
                 cat "$FILE_PATH"
                 exit 0
             ;;
+        oz)
+            zipFiles "$CLIENT_PATH" -q
+
+            FILE_NAME=client.zip
+            FILE_PATH="$CLIENT_PATH/$FILE_NAME"
+            cat "$FILE_PATH"
+            exit 0
+            ;;
+        ozp)
+            if (($# < 2))
+            then
+                echo "$(datef) Not enough arguments" && exit 1
+            else
+                zipFilesWithPassword "$CLIENT_PATH" "$2" -q
+
+                FILE_NAME=client.zip
+                FILE_PATH="$CLIENT_PATH/$FILE_NAME"
+                cat "$FILE_PATH"
+                exit 0
+            fi
+            ;;
         *) echo "$(datef) Unknown parameters $FLAGS"
             ;;
 
@@ -49,8 +71,9 @@ then
 fi
 
 echo "$(datef) Config server started, download your $FILE_NAME config at http://$HOST_ADDR/"
-echo "$(datef) NOTE: After you download you client config, http server will be shut down!"
+echo "$(datef) NOTE: After you download your client config, http server will be shut down!"
 
 { echo -ne "HTTP/1.1 200 OK\r\nContent-Length: $(wc -c <$FILE_PATH)\r\nContent-Type: $CONTENT_TYPE\r\nContent-Disposition: attachment; fileName=\"$FILE_NAME\"\r\nAccept-Ranges: bytes\r\n\r\n"; cat "$FILE_PATH"; } | nc -w0 -l 8080
 
 echo "$(datef) Config http server has been shut down"
+


### PR DESCRIPTION
Hey there!

Things what I have done:

1) Added a new option `oz`, which outputs zip, can be used like `docker exec dockovpn ./genclient.sh oz > my_cert.zip`.
2) Added a new option `ozp`, which outputs zip encrypted with a password. Can be used like `docker exec dockovpn ./genclient.sh ozp StRoNgPaSsWoRd > my_cert.zip` .

Those features required some improvements like:

3) `zipFilesWithPassword()` and `zipFiles()` now have a quite option, e.g. `zipFilesWithPassword "$CLIENT_PATH" "$2" -q`. 
It is required, because it would be odd if it forced you to clear the output from the logging lines.
Lacking of logs when using `o` option has the same reason.
4) Since you can't use logs in the output, I changed exit code from 0 to 1 in case of lacking of arguments.

Also I fixed some spelling mistakes. 

